### PR TITLE
Add Serial 1 support

### DIFF
--- a/ch55xduino/ch55x/cores/ch55xduino/Arduino.h
+++ b/ch55xduino/ch55x/cores/ch55xduino/Arduino.h
@@ -304,6 +304,28 @@ char USBSerial_read();
 #define Serial0_println_fd(P,Q) ( Print_print_fd(Serial0_write,(P),(Q) ) + Print_println(Serial0_write) )
 #define Serial0_println_c(P) ( (Serial0_write(P)) + Print_println(Serial0_write) )
 
+
+#define Serial1_print_s(P) ( Print_print_s(Serial1_write,(P)) )
+#define Serial1_print_sn(P,Q) ( Print_print_sn(Serial1_write,(P),(Q)) )
+#define Serial1_print_i(P) ( Print_print_i(Serial1_write,(P)) )
+#define Serial1_print_u(P) ( Print_print_u(Serial1_write,(P)) )
+#define Serial1_print_ib(P) ( Print_print_ib(Serial1_write,(P)) )
+#define Serial1_print_ub(P,Q) ( Print_print_ub(Serial1_write,(P),(Q)) )
+#define Serial1_print_f(P) ( Print_print_f(Serial1_write,(P)) )
+#define Serial1_print_fd(P,Q) ( Print_print_fd(Serial1_write,(P),(Q)) )
+#define Serial1_print_c(P) ( (Serial1_write(P)) )
+
+#define Serial1_println() ( Print_println(Serial1_write) )
+#define Serial1_println_s(P) ( Print_print_s(Serial1_write,(P)) + Print_println(Serial1_write) )
+#define Serial1_println_sn(P,Q) ( Print_print_sn(Serial1_write,(P),(Q)) + Print_println(Serial1_write) )
+#define Serial1_println_i(P) ( Print_print_i(Serial1_write,(P)) + Print_println(Serial1_write) )
+#define Serial1_println_u(P) ( Print_print_u(Serial1_write,(P)) + Print_println(Serial1_write) )
+#define Serial1_println_ib(P) ( Print_print_ib(Serial1_write,(P)) + Print_println(Serial1_write) )
+#define Serial1_println_ub(P,Q) ( Print_print_ub(Serial1_write,(P),(Q)) + Print_println(Serial1_write) )
+#define Serial1_println_f(P) ( Print_print_f(Serial1_write,(P)) + Print_println(Serial1_write) )
+#define Serial1_println_fd(P,Q) ( Print_print_fd(Serial1_write,(P),(Q) ) + Print_println(Serial1_write) )
+#define Serial1_println_c(P) ( (Serial1_write(P)) + Print_println(Serial1_write) )
+
 //10K lifecycle DataFlash access on CH551/CH552.
 #define eeprom_write_byte(ADDR,VAL) { DPL=(VAL);DPH=(ADDR);eeprom_write_byte_2_params_DPTR(); }
 //SDCC is not efficent to convert 2 8bit data to 1 16bit data, se we use DPTR directly. The mismatch of parameter of the H and C is intentional

--- a/ch55xduino/ch55x/cores/ch55xduino/HardwareSerial.h
+++ b/ch55xduino/ch55x/cores/ch55xduino/HardwareSerial.h
@@ -25,4 +25,18 @@ void Serial0_end(void);
 void uart0IntRxHandler();
 void uart0IntTxHandler();
 
+
+uint8_t Serial1(void);
+void Serial1_begin(unsigned long baud);
+
+uint8_t Serial1_available(void);
+uint8_t Serial1_read(void);
+uint8_t Serial1_write(uint8_t c);
+void Serial1_flush(void);
+
+void Serial1_end(void);
+
+void uart1IntRxHandler();
+void uart1IntTxHandler();
+
 #endif

--- a/ch55xduino/ch55x/cores/ch55xduino/HardwareSerial1.c
+++ b/ch55xduino/ch55x/cores/ch55xduino/HardwareSerial1.c
@@ -1,0 +1,73 @@
+#include "HardwareSerial.h"
+
+__xdata unsigned char serial1Initialized;
+
+extern __xdata uint8_t Receive_Uart1_Buf[];   //arduino style serial buffer
+extern __xdata uint8_t Transmit_Uart1_Buf[];   //arduino style serial buffer
+extern volatile __xdata uint8_t uart1_rx_buffer_head;
+extern volatile __xdata uint8_t uart1_rx_buffer_tail;
+extern volatile __xdata uint8_t uart1_tx_buffer_head;
+extern volatile __xdata uint8_t uart1_tx_buffer_tail;
+extern volatile __bit uart1_flag_sending;
+
+//extern wait functions
+void delayMicroseconds(uint16_t us);
+
+uint8_t Serial1(void){
+    return serial1Initialized;
+}
+
+void Serial1_begin(unsigned long baud){
+    U1SM0 = 0;
+    U1SMOD = 1;                                                                  //use mode 1 for serial 1
+    U1REN = 1;                                                                   //Enable serial 1 receive
+
+    SBAUD1 = 256 - F_CPU / 16 / baud;
+
+    IE_UART1 = 1;
+    EA = 1;                                                                       //Enable serial 1 interrupt
+
+    serial1Initialized = 1;
+}
+
+uint8_t Serial1_write(uint8_t SendDat)
+{
+    if ( (uart1_tx_buffer_head == uart1_tx_buffer_tail) && (uart1_flag_sending==0) ){    //start to send
+        uart1_flag_sending = 1;
+        SBUF1 = SendDat;
+        return 1;
+    }
+
+    uint8_t nextHeadPos =  ((uint8_t)(uart1_tx_buffer_head + 1)) % SERIAL1_TX_BUFFER_SIZE;
+
+    uint16_t waitWriteCount=0;
+    while ((nextHeadPos == uart1_tx_buffer_tail) ){    //wait max 100ms or discard
+        waitWriteCount++;
+        delayMicroseconds(5);
+        if (waitWriteCount>=20000) return 0;
+    }
+    Transmit_Uart1_Buf[uart1_tx_buffer_head]=SendDat;
+
+    uart1_tx_buffer_head = nextHeadPos;
+
+    return 1;
+}
+
+void Serial1_flush(void){
+    while( uart1_flag_sending );
+}
+
+uint8_t Serial1_available(void){
+    uint8_t rxBufLength = ((uint8_t)(SERIAL1_RX_BUFFER_SIZE + uart1_rx_buffer_head - uart1_rx_buffer_tail)) % SERIAL1_RX_BUFFER_SIZE;
+    return rxBufLength;
+}
+
+uint8_t Serial1_read(void){
+    uint8_t rxBufLength = ((uint8_t)(SERIAL1_RX_BUFFER_SIZE + uart1_rx_buffer_head - uart1_rx_buffer_tail)) % SERIAL1_RX_BUFFER_SIZE;
+    if(rxBufLength>0){
+        uint8_t result = Receive_Uart1_Buf[uart1_rx_buffer_tail];
+        uart1_rx_buffer_tail = (((uint8_t)(uart1_rx_buffer_tail + 1)) % SERIAL1_RX_BUFFER_SIZE);
+        return result;
+    }
+    return 0;
+}

--- a/ch55xduino/ch55x/cores/ch55xduino/HardwareSerial1ISR.c
+++ b/ch55xduino/ch55x/cores/ch55xduino/HardwareSerial1ISR.c
@@ -1,0 +1,32 @@
+#include "HardwareSerial.h"
+
+__xdata uint8_t Receive_Uart1_Buf[SERIAL1_RX_BUFFER_SIZE];   //arduino style serial buffer
+__xdata uint8_t Transmit_Uart1_Buf[SERIAL1_TX_BUFFER_SIZE];   //arduino style serial buffer
+volatile __xdata uint8_t uart1_rx_buffer_head=0;
+volatile __xdata uint8_t uart1_rx_buffer_tail=0;
+volatile __xdata uint8_t uart1_tx_buffer_head=0;
+volatile __xdata uint8_t uart1_tx_buffer_tail=0;
+volatile __bit uart1_flag_sending=0;
+
+void uart1IntRxHandler(){
+    uint8_t nextHead = (uart1_rx_buffer_head + 1) % SERIAL1_RX_BUFFER_SIZE;
+
+    if (nextHead != uart1_rx_buffer_tail) {
+        Receive_Uart1_Buf[uart1_rx_buffer_head] = SBUF1;
+        uart1_rx_buffer_head = nextHead;
+    }
+}
+
+void uart1IntTxHandler(){
+    if (uart1_flag_sending){
+        if (uart1_tx_buffer_head == uart1_tx_buffer_tail){
+            //do no more
+            uart1_flag_sending &= 0;
+        }else{
+            SBUF1=Transmit_Uart1_Buf[uart1_tx_buffer_tail];
+            uart1_tx_buffer_tail = (uart1_tx_buffer_tail + 1) % SERIAL1_TX_BUFFER_SIZE;
+        }
+    }
+}
+
+

--- a/ch55xduino/ch55x/cores/ch55xduino/main.c
+++ b/ch55xduino/ch55x/cores/ch55xduino/main.c
@@ -47,6 +47,18 @@ void Uart0_ISR(void) __interrupt (INT_NO_UART0)
     }
 }
 
+void Uart1_ISR(void) __interrupt (INT_NO_UART1)
+{
+    if (U1RI){
+        uart1IntRxHandler();
+        U1RI =0;
+    }
+    if (U1TI){
+        uart1IntTxHandler();
+        U1TI =0;
+    }
+}
+
 typedef void (*voidFuncPtr)(void);
 extern __xdata voidFuncPtr intFunc[];
 void INT0_ISR(void) __interrupt (INT_NO_INT0)


### PR DESCRIPTION
On the CH554 MSOP package, P1.2/P1.3, P3.0/P3.1, P3.4/P3.2 are all not accessible, making P1.6/P1.7 the only pins that UART can be used, and those are used by UART1.

All the code is just copied Serial 0 stuff with changed registers and the way baudrate is set, nothing more.

Verified on HW.