### PR TITLE
Fix WS2812 sometimes displaying incorrect colors

### DIFF
--- a/ch55xduino/ch55x/libraries/WS2812/src/template/WS2812_PIN_._c
+++ b/ch55xduino/ch55x/libraries/WS2812/src/template/WS2812_PIN_._c
@@ -25,47 +25,44 @@ void neopixel_show_long_PX_X(uint32_t dataAndLen) {
            ";disable interrupt                      \n"
            "    clr _EA                             \n"
 
-           //even may skip a byte, may leaving it 0xFF, and the MOV R7,A may affect R7
-           //CH552 can save 1 instruction of jump/branch insctruction go to an even addr
-           ".even                                   \n"
+           //.even may skip a byte, leaving it 0xFF
+           //CH55x can save 1 cycle (or more) of jump/branch instructions going from/to an even addr
+           ".even                                   \n" // [bytes, cycles]
            "startNewByte$:                          \n"
-           "    movx  a,@dptr                       \n"
-           "    inc dptr                            \n"
+           "    movx  a,@dptr                       \n" // [1,1]
+           "    inc dptr                            \n" // [1,1]
+           "    mov r2,#8                           \n" // [2,2]
            "loopbit$:                               \n"
-           "    setb _PX_X                          \n"
-           "    rlc a                               \n"
-           "    nop                                 \n"  //make it even
-           "    jnc bit7skipLowNop$                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "bit7skipLowNop$:                        \n"
-           "    clr _PX_X                           \n"
-           "    jc bit7skipHighNop$                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
+           "    setb _PX_X                          \n" // [2,2]
+           "    rlc a                               \n" // [1,1]
+           "    nop                                 \n" // [1,1] //make it even
+           "    jnc bit7skipHighNop$                \n" // [2,2/4|5]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
            "bit7skipHighNop$:                       \n"
-           "    anl ar2,#7                          \n"
-
-           "    djnz r2,loopbit$                    \n"
-           "    djnz r3,startNewByte$               \n"
-           "    nop                                 \n"
-           "    clr _PX_X                          \n"
+           "    clr _PX_X                           \n" // [2,2]
+           "    jc bit7skipLowNop$                  \n" // [2,2/4|5]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "bit7skipLowNop$:                        \n"
+           "    djnz r2,loopbit$                    \n" // [2,2/4|5|6]
+           "    djnz r3,startNewByte$               \n" // [2,2/4|5|6]
 
            ";restore EA from R6                     \n"
            "    mov a,r6                            \n"

--- a/ch55xduino/ch55x/libraries/WS2812/src/template/optionalLink_WS2812_P1_0.c
+++ b/ch55xduino/ch55x/libraries/WS2812/src/template/optionalLink_WS2812_P1_0.c
@@ -26,47 +26,44 @@ void neopixel_show_long_P1_0(uint32_t dataAndLen) {
            ";disable interrupt                      \n"
            "    clr _EA                             \n"
 
-           //even may skip a byte, may leaving it 0xFF, and the MOV R7,A may affect R7
-           //CH552 can save 1 instruction of jump/branch insctruction go to an even addr
-           ".even                                   \n"
+           //.even may skip a byte, leaving it 0xFF
+           //CH55x can save 1 cycle (or more) of jump/branch instructions going from/to an even addr
+           ".even                                   \n" // [bytes, cycles]
            "startNewByte$:                          \n"
-           "    movx  a,@dptr                       \n"
-           "    inc dptr                            \n"
+           "    movx  a,@dptr                       \n" // [1,1]
+           "    inc dptr                            \n" // [1,1]
+           "    mov r2,#8                           \n" // [2,2]
            "loopbit$:                               \n"
-           "    setb _P1_0                          \n"
-           "    rlc a                               \n"
-           "    nop                                 \n"  //make it even
-           "    jnc bit7skipLowNop$                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "bit7skipLowNop$:                        \n"
-           "    clr _P1_0                           \n"
-           "    jc bit7skipHighNop$                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
+           "    setb _P1_0                          \n" // [2,2]
+           "    rlc a                               \n" // [1,1]
+           "    nop                                 \n" // [1,1] //make it even
+           "    jnc bit7skipHighNop$                \n" // [2,2/4|5]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
            "bit7skipHighNop$:                       \n"
-           "    anl ar2,#7                          \n"
-
-           "    djnz r2,loopbit$                    \n"
-           "    djnz r3,startNewByte$               \n"
-           "    nop                                 \n"
-           "    clr _P1_0                          \n"
+           "    clr _P1_0                           \n" // [2,2]
+           "    jc bit7skipLowNop$                  \n" // [2,2/4|5]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "bit7skipLowNop$:                        \n"
+           "    djnz r2,loopbit$                    \n" // [2,2/4|5|6]
+           "    djnz r3,startNewByte$               \n" // [2,2/4|5|6]
 
            ";restore EA from R6                     \n"
            "    mov a,r6                            \n"

--- a/ch55xduino/ch55x/libraries/WS2812/src/template/optionalLink_WS2812_P1_1.c
+++ b/ch55xduino/ch55x/libraries/WS2812/src/template/optionalLink_WS2812_P1_1.c
@@ -26,47 +26,44 @@ void neopixel_show_long_P1_1(uint32_t dataAndLen) {
            ";disable interrupt                      \n"
            "    clr _EA                             \n"
 
-           //even may skip a byte, may leaving it 0xFF, and the MOV R7,A may affect R7
-           //CH552 can save 1 instruction of jump/branch insctruction go to an even addr
-           ".even                                   \n"
+           //.even may skip a byte, leaving it 0xFF
+           //CH55x can save 1 cycle (or more) of jump/branch instructions going from/to an even addr
+           ".even                                   \n" // [bytes, cycles]
            "startNewByte$:                          \n"
-           "    movx  a,@dptr                       \n"
-           "    inc dptr                            \n"
+           "    movx  a,@dptr                       \n" // [1,1]
+           "    inc dptr                            \n" // [1,1]
+           "    mov r2,#8                           \n" // [2,2]
            "loopbit$:                               \n"
-           "    setb _P1_1                          \n"
-           "    rlc a                               \n"
-           "    nop                                 \n"  //make it even
-           "    jnc bit7skipLowNop$                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "bit7skipLowNop$:                        \n"
-           "    clr _P1_1                           \n"
-           "    jc bit7skipHighNop$                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
+           "    setb _P1_1                          \n" // [2,2]
+           "    rlc a                               \n" // [1,1]
+           "    nop                                 \n" // [1,1] //make it even
+           "    jnc bit7skipHighNop$                \n" // [2,2/4|5]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
            "bit7skipHighNop$:                       \n"
-           "    anl ar2,#7                          \n"
-
-           "    djnz r2,loopbit$                    \n"
-           "    djnz r3,startNewByte$               \n"
-           "    nop                                 \n"
-           "    clr _P1_1                          \n"
+           "    clr _P1_1                           \n" // [2,2]
+           "    jc bit7skipLowNop$                  \n" // [2,2/4|5]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "bit7skipLowNop$:                        \n"
+           "    djnz r2,loopbit$                    \n" // [2,2/4|5|6]
+           "    djnz r3,startNewByte$               \n" // [2,2/4|5|6]
 
            ";restore EA from R6                     \n"
            "    mov a,r6                            \n"

--- a/ch55xduino/ch55x/libraries/WS2812/src/template/optionalLink_WS2812_P1_2.c
+++ b/ch55xduino/ch55x/libraries/WS2812/src/template/optionalLink_WS2812_P1_2.c
@@ -26,47 +26,44 @@ void neopixel_show_long_P1_2(uint32_t dataAndLen) {
            ";disable interrupt                      \n"
            "    clr _EA                             \n"
 
-           //even may skip a byte, may leaving it 0xFF, and the MOV R7,A may affect R7
-           //CH552 can save 1 instruction of jump/branch insctruction go to an even addr
-           ".even                                   \n"
+           //.even may skip a byte, leaving it 0xFF
+           //CH55x can save 1 cycle (or more) of jump/branch instructions going from/to an even addr
+           ".even                                   \n" // [bytes, cycles]
            "startNewByte$:                          \n"
-           "    movx  a,@dptr                       \n"
-           "    inc dptr                            \n"
+           "    movx  a,@dptr                       \n" // [1,1]
+           "    inc dptr                            \n" // [1,1]
+           "    mov r2,#8                           \n" // [2,2]
            "loopbit$:                               \n"
-           "    setb _P1_2                          \n"
-           "    rlc a                               \n"
-           "    nop                                 \n"  //make it even
-           "    jnc bit7skipLowNop$                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "bit7skipLowNop$:                        \n"
-           "    clr _P1_2                           \n"
-           "    jc bit7skipHighNop$                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
+           "    setb _P1_2                          \n" // [2,2]
+           "    rlc a                               \n" // [1,1]
+           "    nop                                 \n" // [1,1] //make it even
+           "    jnc bit7skipHighNop$                \n" // [2,2/4|5]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
            "bit7skipHighNop$:                       \n"
-           "    anl ar2,#7                          \n"
-
-           "    djnz r2,loopbit$                    \n"
-           "    djnz r3,startNewByte$               \n"
-           "    nop                                 \n"
-           "    clr _P1_2                          \n"
+           "    clr _P1_2                           \n" // [2,2]
+           "    jc bit7skipLowNop$                  \n" // [2,2/4|5]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "bit7skipLowNop$:                        \n"
+           "    djnz r2,loopbit$                    \n" // [2,2/4|5|6]
+           "    djnz r3,startNewByte$               \n" // [2,2/4|5|6]
 
            ";restore EA from R6                     \n"
            "    mov a,r6                            \n"

--- a/ch55xduino/ch55x/libraries/WS2812/src/template/optionalLink_WS2812_P1_3.c
+++ b/ch55xduino/ch55x/libraries/WS2812/src/template/optionalLink_WS2812_P1_3.c
@@ -26,47 +26,44 @@ void neopixel_show_long_P1_3(uint32_t dataAndLen) {
            ";disable interrupt                      \n"
            "    clr _EA                             \n"
 
-           //even may skip a byte, may leaving it 0xFF, and the MOV R7,A may affect R7
-           //CH552 can save 1 instruction of jump/branch insctruction go to an even addr
-           ".even                                   \n"
+           //.even may skip a byte, leaving it 0xFF
+           //CH55x can save 1 cycle (or more) of jump/branch instructions going from/to an even addr
+           ".even                                   \n" // [bytes, cycles]
            "startNewByte$:                          \n"
-           "    movx  a,@dptr                       \n"
-           "    inc dptr                            \n"
+           "    movx  a,@dptr                       \n" // [1,1]
+           "    inc dptr                            \n" // [1,1]
+           "    mov r2,#8                           \n" // [2,2]
            "loopbit$:                               \n"
-           "    setb _P1_3                          \n"
-           "    rlc a                               \n"
-           "    nop                                 \n"  //make it even
-           "    jnc bit7skipLowNop$                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "bit7skipLowNop$:                        \n"
-           "    clr _P1_3                           \n"
-           "    jc bit7skipHighNop$                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
+           "    setb _P1_3                          \n" // [2,2]
+           "    rlc a                               \n" // [1,1]
+           "    nop                                 \n" // [1,1] //make it even
+           "    jnc bit7skipHighNop$                \n" // [2,2/4|5]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
            "bit7skipHighNop$:                       \n"
-           "    anl ar2,#7                          \n"
-
-           "    djnz r2,loopbit$                    \n"
-           "    djnz r3,startNewByte$               \n"
-           "    nop                                 \n"
-           "    clr _P1_3                          \n"
+           "    clr _P1_3                           \n" // [2,2]
+           "    jc bit7skipLowNop$                  \n" // [2,2/4|5]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "bit7skipLowNop$:                        \n"
+           "    djnz r2,loopbit$                    \n" // [2,2/4|5|6]
+           "    djnz r3,startNewByte$               \n" // [2,2/4|5|6]
 
            ";restore EA from R6                     \n"
            "    mov a,r6                            \n"

--- a/ch55xduino/ch55x/libraries/WS2812/src/template/optionalLink_WS2812_P1_4.c
+++ b/ch55xduino/ch55x/libraries/WS2812/src/template/optionalLink_WS2812_P1_4.c
@@ -26,47 +26,44 @@ void neopixel_show_long_P1_4(uint32_t dataAndLen) {
            ";disable interrupt                      \n"
            "    clr _EA                             \n"
 
-           //even may skip a byte, may leaving it 0xFF, and the MOV R7,A may affect R7
-           //CH552 can save 1 instruction of jump/branch insctruction go to an even addr
-           ".even                                   \n"
+           //.even may skip a byte, leaving it 0xFF
+           //CH55x can save 1 cycle (or more) of jump/branch instructions going from/to an even addr
+           ".even                                   \n" // [bytes, cycles]
            "startNewByte$:                          \n"
-           "    movx  a,@dptr                       \n"
-           "    inc dptr                            \n"
+           "    movx  a,@dptr                       \n" // [1,1]
+           "    inc dptr                            \n" // [1,1]
+           "    mov r2,#8                           \n" // [2,2]
            "loopbit$:                               \n"
-           "    setb _P1_4                          \n"
-           "    rlc a                               \n"
-           "    nop                                 \n"  //make it even
-           "    jnc bit7skipLowNop$                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "bit7skipLowNop$:                        \n"
-           "    clr _P1_4                           \n"
-           "    jc bit7skipHighNop$                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
+           "    setb _P1_4                          \n" // [2,2]
+           "    rlc a                               \n" // [1,1]
+           "    nop                                 \n" // [1,1] //make it even
+           "    jnc bit7skipHighNop$                \n" // [2,2/4|5]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
            "bit7skipHighNop$:                       \n"
-           "    anl ar2,#7                          \n"
-
-           "    djnz r2,loopbit$                    \n"
-           "    djnz r3,startNewByte$               \n"
-           "    nop                                 \n"
-           "    clr _P1_4                          \n"
+           "    clr _P1_4                           \n" // [2,2]
+           "    jc bit7skipLowNop$                  \n" // [2,2/4|5]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "bit7skipLowNop$:                        \n"
+           "    djnz r2,loopbit$                    \n" // [2,2/4|5|6]
+           "    djnz r3,startNewByte$               \n" // [2,2/4|5|6]
 
            ";restore EA from R6                     \n"
            "    mov a,r6                            \n"

--- a/ch55xduino/ch55x/libraries/WS2812/src/template/optionalLink_WS2812_P1_5.c
+++ b/ch55xduino/ch55x/libraries/WS2812/src/template/optionalLink_WS2812_P1_5.c
@@ -26,47 +26,44 @@ void neopixel_show_long_P1_5(uint32_t dataAndLen) {
            ";disable interrupt                      \n"
            "    clr _EA                             \n"
 
-           //even may skip a byte, may leaving it 0xFF, and the MOV R7,A may affect R7
-           //CH552 can save 1 instruction of jump/branch insctruction go to an even addr
-           ".even                                   \n"
+           //.even may skip a byte, leaving it 0xFF
+           //CH55x can save 1 cycle (or more) of jump/branch instructions going from/to an even addr
+           ".even                                   \n" // [bytes, cycles]
            "startNewByte$:                          \n"
-           "    movx  a,@dptr                       \n"
-           "    inc dptr                            \n"
+           "    movx  a,@dptr                       \n" // [1,1]
+           "    inc dptr                            \n" // [1,1]
+           "    mov r2,#8                           \n" // [2,2]
            "loopbit$:                               \n"
-           "    setb _P1_5                          \n"
-           "    rlc a                               \n"
-           "    nop                                 \n"  //make it even
-           "    jnc bit7skipLowNop$                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "bit7skipLowNop$:                        \n"
-           "    clr _P1_5                           \n"
-           "    jc bit7skipHighNop$                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
+           "    setb _P1_5                          \n" // [2,2]
+           "    rlc a                               \n" // [1,1]
+           "    nop                                 \n" // [1,1] //make it even
+           "    jnc bit7skipHighNop$                \n" // [2,2/4|5]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
            "bit7skipHighNop$:                       \n"
-           "    anl ar2,#7                          \n"
-
-           "    djnz r2,loopbit$                    \n"
-           "    djnz r3,startNewByte$               \n"
-           "    nop                                 \n"
-           "    clr _P1_5                          \n"
+           "    clr _P1_5                           \n" // [2,2]
+           "    jc bit7skipLowNop$                  \n" // [2,2/4|5]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "bit7skipLowNop$:                        \n"
+           "    djnz r2,loopbit$                    \n" // [2,2/4|5|6]
+           "    djnz r3,startNewByte$               \n" // [2,2/4|5|6]
 
            ";restore EA from R6                     \n"
            "    mov a,r6                            \n"

--- a/ch55xduino/ch55x/libraries/WS2812/src/template/optionalLink_WS2812_P1_6.c
+++ b/ch55xduino/ch55x/libraries/WS2812/src/template/optionalLink_WS2812_P1_6.c
@@ -26,47 +26,44 @@ void neopixel_show_long_P1_6(uint32_t dataAndLen) {
            ";disable interrupt                      \n"
            "    clr _EA                             \n"
 
-           //even may skip a byte, may leaving it 0xFF, and the MOV R7,A may affect R7
-           //CH552 can save 1 instruction of jump/branch insctruction go to an even addr
-           ".even                                   \n"
+           //.even may skip a byte, leaving it 0xFF
+           //CH55x can save 1 cycle (or more) of jump/branch instructions going from/to an even addr
+           ".even                                   \n" // [bytes, cycles]
            "startNewByte$:                          \n"
-           "    movx  a,@dptr                       \n"
-           "    inc dptr                            \n"
+           "    movx  a,@dptr                       \n" // [1,1]
+           "    inc dptr                            \n" // [1,1]
+           "    mov r2,#8                           \n" // [2,2]
            "loopbit$:                               \n"
-           "    setb _P1_6                          \n"
-           "    rlc a                               \n"
-           "    nop                                 \n"  //make it even
-           "    jnc bit7skipLowNop$                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "bit7skipLowNop$:                        \n"
-           "    clr _P1_6                           \n"
-           "    jc bit7skipHighNop$                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
+           "    setb _P1_6                          \n" // [2,2]
+           "    rlc a                               \n" // [1,1]
+           "    nop                                 \n" // [1,1] //make it even
+           "    jnc bit7skipHighNop$                \n" // [2,2/4|5]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
            "bit7skipHighNop$:                       \n"
-           "    anl ar2,#7                          \n"
-
-           "    djnz r2,loopbit$                    \n"
-           "    djnz r3,startNewByte$               \n"
-           "    nop                                 \n"
-           "    clr _P1_6                          \n"
+           "    clr _P1_6                           \n" // [2,2]
+           "    jc bit7skipLowNop$                  \n" // [2,2/4|5]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "bit7skipLowNop$:                        \n"
+           "    djnz r2,loopbit$                    \n" // [2,2/4|5|6]
+           "    djnz r3,startNewByte$               \n" // [2,2/4|5|6]
 
            ";restore EA from R6                     \n"
            "    mov a,r6                            \n"

--- a/ch55xduino/ch55x/libraries/WS2812/src/template/optionalLink_WS2812_P1_7.c
+++ b/ch55xduino/ch55x/libraries/WS2812/src/template/optionalLink_WS2812_P1_7.c
@@ -26,47 +26,44 @@ void neopixel_show_long_P1_7(uint32_t dataAndLen) {
            ";disable interrupt                      \n"
            "    clr _EA                             \n"
 
-           //even may skip a byte, may leaving it 0xFF, and the MOV R7,A may affect R7
-           //CH552 can save 1 instruction of jump/branch insctruction go to an even addr
-           ".even                                   \n"
+           //.even may skip a byte, leaving it 0xFF
+           //CH55x can save 1 cycle (or more) of jump/branch instructions going from/to an even addr
+           ".even                                   \n" // [bytes, cycles]
            "startNewByte$:                          \n"
-           "    movx  a,@dptr                       \n"
-           "    inc dptr                            \n"
+           "    movx  a,@dptr                       \n" // [1,1]
+           "    inc dptr                            \n" // [1,1]
+           "    mov r2,#8                           \n" // [2,2]
            "loopbit$:                               \n"
-           "    setb _P1_7                          \n"
-           "    rlc a                               \n"
-           "    nop                                 \n"  //make it even
-           "    jnc bit7skipLowNop$                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "bit7skipLowNop$:                        \n"
-           "    clr _P1_7                           \n"
-           "    jc bit7skipHighNop$                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
+           "    setb _P1_7                          \n" // [2,2]
+           "    rlc a                               \n" // [1,1]
+           "    nop                                 \n" // [1,1] //make it even
+           "    jnc bit7skipHighNop$                \n" // [2,2/4|5]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
            "bit7skipHighNop$:                       \n"
-           "    anl ar2,#7                          \n"
-
-           "    djnz r2,loopbit$                    \n"
-           "    djnz r3,startNewByte$               \n"
-           "    nop                                 \n"
-           "    clr _P1_7                          \n"
+           "    clr _P1_7                           \n" // [2,2]
+           "    jc bit7skipLowNop$                  \n" // [2,2/4|5]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "bit7skipLowNop$:                        \n"
+           "    djnz r2,loopbit$                    \n" // [2,2/4|5|6]
+           "    djnz r3,startNewByte$               \n" // [2,2/4|5|6]
 
            ";restore EA from R6                     \n"
            "    mov a,r6                            \n"

--- a/ch55xduino/ch55x/libraries/WS2812/src/template/optionalLink_WS2812_P3_0.c
+++ b/ch55xduino/ch55x/libraries/WS2812/src/template/optionalLink_WS2812_P3_0.c
@@ -26,47 +26,44 @@ void neopixel_show_long_P3_0(uint32_t dataAndLen) {
            ";disable interrupt                      \n"
            "    clr _EA                             \n"
 
-           //even may skip a byte, may leaving it 0xFF, and the MOV R7,A may affect R7
-           //CH552 can save 1 instruction of jump/branch insctruction go to an even addr
-           ".even                                   \n"
+           //.even may skip a byte, leaving it 0xFF
+           //CH55x can save 1 cycle (or more) of jump/branch instructions going from/to an even addr
+           ".even                                   \n" // [bytes, cycles]
            "startNewByte$:                          \n"
-           "    movx  a,@dptr                       \n"
-           "    inc dptr                            \n"
+           "    movx  a,@dptr                       \n" // [1,1]
+           "    inc dptr                            \n" // [1,1]
+           "    mov r2,#8                           \n" // [2,2]
            "loopbit$:                               \n"
-           "    setb _P3_0                          \n"
-           "    rlc a                               \n"
-           "    nop                                 \n"  //make it even
-           "    jnc bit7skipLowNop$                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "bit7skipLowNop$:                        \n"
-           "    clr _P3_0                           \n"
-           "    jc bit7skipHighNop$                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
+           "    setb _P3_0                          \n" // [2,2]
+           "    rlc a                               \n" // [1,1]
+           "    nop                                 \n" // [1,1] //make it even
+           "    jnc bit7skipHighNop$                \n" // [2,2/4|5]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
            "bit7skipHighNop$:                       \n"
-           "    anl ar2,#7                          \n"
-
-           "    djnz r2,loopbit$                    \n"
-           "    djnz r3,startNewByte$               \n"
-           "    nop                                 \n"
-           "    clr _P3_0                          \n"
+           "    clr _P3_0                           \n" // [2,2]
+           "    jc bit7skipLowNop$                  \n" // [2,2/4|5]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "bit7skipLowNop$:                        \n"
+           "    djnz r2,loopbit$                    \n" // [2,2/4|5|6]
+           "    djnz r3,startNewByte$               \n" // [2,2/4|5|6]
 
            ";restore EA from R6                     \n"
            "    mov a,r6                            \n"

--- a/ch55xduino/ch55x/libraries/WS2812/src/template/optionalLink_WS2812_P3_1.c
+++ b/ch55xduino/ch55x/libraries/WS2812/src/template/optionalLink_WS2812_P3_1.c
@@ -26,47 +26,44 @@ void neopixel_show_long_P3_1(uint32_t dataAndLen) {
            ";disable interrupt                      \n"
            "    clr _EA                             \n"
 
-           //even may skip a byte, may leaving it 0xFF, and the MOV R7,A may affect R7
-           //CH552 can save 1 instruction of jump/branch insctruction go to an even addr
-           ".even                                   \n"
+           //.even may skip a byte, leaving it 0xFF
+           //CH55x can save 1 cycle (or more) of jump/branch instructions going from/to an even addr
+           ".even                                   \n" // [bytes, cycles]
            "startNewByte$:                          \n"
-           "    movx  a,@dptr                       \n"
-           "    inc dptr                            \n"
+           "    movx  a,@dptr                       \n" // [1,1]
+           "    inc dptr                            \n" // [1,1]
+           "    mov r2,#8                           \n" // [2,2]
            "loopbit$:                               \n"
-           "    setb _P3_1                          \n"
-           "    rlc a                               \n"
-           "    nop                                 \n"  //make it even
-           "    jnc bit7skipLowNop$                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "bit7skipLowNop$:                        \n"
-           "    clr _P3_1                           \n"
-           "    jc bit7skipHighNop$                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
+           "    setb _P3_1                          \n" // [2,2]
+           "    rlc a                               \n" // [1,1]
+           "    nop                                 \n" // [1,1] //make it even
+           "    jnc bit7skipHighNop$                \n" // [2,2/4|5]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
            "bit7skipHighNop$:                       \n"
-           "    anl ar2,#7                          \n"
-
-           "    djnz r2,loopbit$                    \n"
-           "    djnz r3,startNewByte$               \n"
-           "    nop                                 \n"
-           "    clr _P3_1                          \n"
+           "    clr _P3_1                           \n" // [2,2]
+           "    jc bit7skipLowNop$                  \n" // [2,2/4|5]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "bit7skipLowNop$:                        \n"
+           "    djnz r2,loopbit$                    \n" // [2,2/4|5|6]
+           "    djnz r3,startNewByte$               \n" // [2,2/4|5|6]
 
            ";restore EA from R6                     \n"
            "    mov a,r6                            \n"

--- a/ch55xduino/ch55x/libraries/WS2812/src/template/optionalLink_WS2812_P3_2.c
+++ b/ch55xduino/ch55x/libraries/WS2812/src/template/optionalLink_WS2812_P3_2.c
@@ -26,47 +26,44 @@ void neopixel_show_long_P3_2(uint32_t dataAndLen) {
            ";disable interrupt                      \n"
            "    clr _EA                             \n"
 
-           //even may skip a byte, may leaving it 0xFF, and the MOV R7,A may affect R7
-           //CH552 can save 1 instruction of jump/branch insctruction go to an even addr
-           ".even                                   \n"
+           //.even may skip a byte, leaving it 0xFF
+           //CH55x can save 1 cycle (or more) of jump/branch instructions going from/to an even addr
+           ".even                                   \n" // [bytes, cycles]
            "startNewByte$:                          \n"
-           "    movx  a,@dptr                       \n"
-           "    inc dptr                            \n"
+           "    movx  a,@dptr                       \n" // [1,1]
+           "    inc dptr                            \n" // [1,1]
+           "    mov r2,#8                           \n" // [2,2]
            "loopbit$:                               \n"
-           "    setb _P3_2                          \n"
-           "    rlc a                               \n"
-           "    nop                                 \n"  //make it even
-           "    jnc bit7skipLowNop$                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "bit7skipLowNop$:                        \n"
-           "    clr _P3_2                           \n"
-           "    jc bit7skipHighNop$                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
+           "    setb _P3_2                          \n" // [2,2]
+           "    rlc a                               \n" // [1,1]
+           "    nop                                 \n" // [1,1] //make it even
+           "    jnc bit7skipHighNop$                \n" // [2,2/4|5]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
            "bit7skipHighNop$:                       \n"
-           "    anl ar2,#7                          \n"
-
-           "    djnz r2,loopbit$                    \n"
-           "    djnz r3,startNewByte$               \n"
-           "    nop                                 \n"
-           "    clr _P3_2                          \n"
+           "    clr _P3_2                           \n" // [2,2]
+           "    jc bit7skipLowNop$                  \n" // [2,2/4|5]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "bit7skipLowNop$:                        \n"
+           "    djnz r2,loopbit$                    \n" // [2,2/4|5|6]
+           "    djnz r3,startNewByte$               \n" // [2,2/4|5|6]
 
            ";restore EA from R6                     \n"
            "    mov a,r6                            \n"

--- a/ch55xduino/ch55x/libraries/WS2812/src/template/optionalLink_WS2812_P3_3.c
+++ b/ch55xduino/ch55x/libraries/WS2812/src/template/optionalLink_WS2812_P3_3.c
@@ -26,47 +26,44 @@ void neopixel_show_long_P3_3(uint32_t dataAndLen) {
            ";disable interrupt                      \n"
            "    clr _EA                             \n"
 
-           //even may skip a byte, may leaving it 0xFF, and the MOV R7,A may affect R7
-           //CH552 can save 1 instruction of jump/branch insctruction go to an even addr
-           ".even                                   \n"
+           //.even may skip a byte, leaving it 0xFF
+           //CH55x can save 1 cycle (or more) of jump/branch instructions going from/to an even addr
+           ".even                                   \n" // [bytes, cycles]
            "startNewByte$:                          \n"
-           "    movx  a,@dptr                       \n"
-           "    inc dptr                            \n"
+           "    movx  a,@dptr                       \n" // [1,1]
+           "    inc dptr                            \n" // [1,1]
+           "    mov r2,#8                           \n" // [2,2]
            "loopbit$:                               \n"
-           "    setb _P3_3                          \n"
-           "    rlc a                               \n"
-           "    nop                                 \n"  //make it even
-           "    jnc bit7skipLowNop$                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "bit7skipLowNop$:                        \n"
-           "    clr _P3_3                           \n"
-           "    jc bit7skipHighNop$                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
+           "    setb _P3_3                          \n" // [2,2]
+           "    rlc a                               \n" // [1,1]
+           "    nop                                 \n" // [1,1] //make it even
+           "    jnc bit7skipHighNop$                \n" // [2,2/4|5]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
            "bit7skipHighNop$:                       \n"
-           "    anl ar2,#7                          \n"
-
-           "    djnz r2,loopbit$                    \n"
-           "    djnz r3,startNewByte$               \n"
-           "    nop                                 \n"
-           "    clr _P3_3                          \n"
+           "    clr _P3_3                           \n" // [2,2]
+           "    jc bit7skipLowNop$                  \n" // [2,2/4|5]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "bit7skipLowNop$:                        \n"
+           "    djnz r2,loopbit$                    \n" // [2,2/4|5|6]
+           "    djnz r3,startNewByte$               \n" // [2,2/4|5|6]
 
            ";restore EA from R6                     \n"
            "    mov a,r6                            \n"

--- a/ch55xduino/ch55x/libraries/WS2812/src/template/optionalLink_WS2812_P3_4.c
+++ b/ch55xduino/ch55x/libraries/WS2812/src/template/optionalLink_WS2812_P3_4.c
@@ -26,47 +26,44 @@ void neopixel_show_long_P3_4(uint32_t dataAndLen) {
            ";disable interrupt                      \n"
            "    clr _EA                             \n"
 
-           //even may skip a byte, may leaving it 0xFF, and the MOV R7,A may affect R7
-           //CH552 can save 1 instruction of jump/branch insctruction go to an even addr
-           ".even                                   \n"
+           //.even may skip a byte, leaving it 0xFF
+           //CH55x can save 1 cycle (or more) of jump/branch instructions going from/to an even addr
+           ".even                                   \n" // [bytes, cycles]
            "startNewByte$:                          \n"
-           "    movx  a,@dptr                       \n"
-           "    inc dptr                            \n"
+           "    movx  a,@dptr                       \n" // [1,1]
+           "    inc dptr                            \n" // [1,1]
+           "    mov r2,#8                           \n" // [2,2]
            "loopbit$:                               \n"
-           "    setb _P3_4                          \n"
-           "    rlc a                               \n"
-           "    nop                                 \n"  //make it even
-           "    jnc bit7skipLowNop$                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "bit7skipLowNop$:                        \n"
-           "    clr _P3_4                           \n"
-           "    jc bit7skipHighNop$                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
+           "    setb _P3_4                          \n" // [2,2]
+           "    rlc a                               \n" // [1,1]
+           "    nop                                 \n" // [1,1] //make it even
+           "    jnc bit7skipHighNop$                \n" // [2,2/4|5]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
            "bit7skipHighNop$:                       \n"
-           "    anl ar2,#7                          \n"
-
-           "    djnz r2,loopbit$                    \n"
-           "    djnz r3,startNewByte$               \n"
-           "    nop                                 \n"
-           "    clr _P3_4                          \n"
+           "    clr _P3_4                           \n" // [2,2]
+           "    jc bit7skipLowNop$                  \n" // [2,2/4|5]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "bit7skipLowNop$:                        \n"
+           "    djnz r2,loopbit$                    \n" // [2,2/4|5|6]
+           "    djnz r3,startNewByte$               \n" // [2,2/4|5|6]
 
            ";restore EA from R6                     \n"
            "    mov a,r6                            \n"

--- a/ch55xduino/ch55x/libraries/WS2812/src/template/optionalLink_WS2812_P3_5.c
+++ b/ch55xduino/ch55x/libraries/WS2812/src/template/optionalLink_WS2812_P3_5.c
@@ -26,47 +26,44 @@ void neopixel_show_long_P3_5(uint32_t dataAndLen) {
            ";disable interrupt                      \n"
            "    clr _EA                             \n"
 
-           //even may skip a byte, may leaving it 0xFF, and the MOV R7,A may affect R7
-           //CH552 can save 1 instruction of jump/branch insctruction go to an even addr
-           ".even                                   \n"
+           //.even may skip a byte, leaving it 0xFF
+           //CH55x can save 1 cycle (or more) of jump/branch instructions going from/to an even addr
+           ".even                                   \n" // [bytes, cycles]
            "startNewByte$:                          \n"
-           "    movx  a,@dptr                       \n"
-           "    inc dptr                            \n"
+           "    movx  a,@dptr                       \n" // [1,1]
+           "    inc dptr                            \n" // [1,1]
+           "    mov r2,#8                           \n" // [2,2]
            "loopbit$:                               \n"
-           "    setb _P3_5                          \n"
-           "    rlc a                               \n"
-           "    nop                                 \n"  //make it even
-           "    jnc bit7skipLowNop$                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "bit7skipLowNop$:                        \n"
-           "    clr _P3_5                           \n"
-           "    jc bit7skipHighNop$                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
+           "    setb _P3_5                          \n" // [2,2]
+           "    rlc a                               \n" // [1,1]
+           "    nop                                 \n" // [1,1] //make it even
+           "    jnc bit7skipHighNop$                \n" // [2,2/4|5]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
            "bit7skipHighNop$:                       \n"
-           "    anl ar2,#7                          \n"
-
-           "    djnz r2,loopbit$                    \n"
-           "    djnz r3,startNewByte$               \n"
-           "    nop                                 \n"
-           "    clr _P3_5                          \n"
+           "    clr _P3_5                           \n" // [2,2]
+           "    jc bit7skipLowNop$                  \n" // [2,2/4|5]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "bit7skipLowNop$:                        \n"
+           "    djnz r2,loopbit$                    \n" // [2,2/4|5|6]
+           "    djnz r3,startNewByte$               \n" // [2,2/4|5|6]
 
            ";restore EA from R6                     \n"
            "    mov a,r6                            \n"

--- a/ch55xduino/ch55x/libraries/WS2812/src/template/optionalLink_WS2812_P3_6.c
+++ b/ch55xduino/ch55x/libraries/WS2812/src/template/optionalLink_WS2812_P3_6.c
@@ -26,47 +26,44 @@ void neopixel_show_long_P3_6(uint32_t dataAndLen) {
            ";disable interrupt                      \n"
            "    clr _EA                             \n"
 
-           //even may skip a byte, may leaving it 0xFF, and the MOV R7,A may affect R7
-           //CH552 can save 1 instruction of jump/branch insctruction go to an even addr
-           ".even                                   \n"
+           //.even may skip a byte, leaving it 0xFF
+           //CH55x can save 1 cycle (or more) of jump/branch instructions going from/to an even addr
+           ".even                                   \n" // [bytes, cycles]
            "startNewByte$:                          \n"
-           "    movx  a,@dptr                       \n"
-           "    inc dptr                            \n"
+           "    movx  a,@dptr                       \n" // [1,1]
+           "    inc dptr                            \n" // [1,1]
+           "    mov r2,#8                           \n" // [2,2]
            "loopbit$:                               \n"
-           "    setb _P3_6                          \n"
-           "    rlc a                               \n"
-           "    nop                                 \n"  //make it even
-           "    jnc bit7skipLowNop$                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "bit7skipLowNop$:                        \n"
-           "    clr _P3_6                           \n"
-           "    jc bit7skipHighNop$                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
+           "    setb _P3_6                          \n" // [2,2]
+           "    rlc a                               \n" // [1,1]
+           "    nop                                 \n" // [1,1] //make it even
+           "    jnc bit7skipHighNop$                \n" // [2,2/4|5]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
            "bit7skipHighNop$:                       \n"
-           "    anl ar2,#7                          \n"
-
-           "    djnz r2,loopbit$                    \n"
-           "    djnz r3,startNewByte$               \n"
-           "    nop                                 \n"
-           "    clr _P3_6                          \n"
+           "    clr _P3_6                           \n" // [2,2]
+           "    jc bit7skipLowNop$                  \n" // [2,2/4|5]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "bit7skipLowNop$:                        \n"
+           "    djnz r2,loopbit$                    \n" // [2,2/4|5|6]
+           "    djnz r3,startNewByte$               \n" // [2,2/4|5|6]
 
            ";restore EA from R6                     \n"
            "    mov a,r6                            \n"

--- a/ch55xduino/ch55x/libraries/WS2812/src/template/optionalLink_WS2812_P3_7.c
+++ b/ch55xduino/ch55x/libraries/WS2812/src/template/optionalLink_WS2812_P3_7.c
@@ -26,47 +26,44 @@ void neopixel_show_long_P3_7(uint32_t dataAndLen) {
            ";disable interrupt                      \n"
            "    clr _EA                             \n"
 
-           //even may skip a byte, may leaving it 0xFF, and the MOV R7,A may affect R7
-           //CH552 can save 1 instruction of jump/branch insctruction go to an even addr
-           ".even                                   \n"
+           //.even may skip a byte, leaving it 0xFF
+           //CH55x can save 1 cycle (or more) of jump/branch instructions going from/to an even addr
+           ".even                                   \n" // [bytes, cycles]
            "startNewByte$:                          \n"
-           "    movx  a,@dptr                       \n"
-           "    inc dptr                            \n"
+           "    movx  a,@dptr                       \n" // [1,1]
+           "    inc dptr                            \n" // [1,1]
+           "    mov r2,#8                           \n" // [2,2]
            "loopbit$:                               \n"
-           "    setb _P3_7                          \n"
-           "    rlc a                               \n"
-           "    nop                                 \n"  //make it even
-           "    jnc bit7skipLowNop$                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "bit7skipLowNop$:                        \n"
-           "    clr _P3_7                           \n"
-           "    jc bit7skipHighNop$                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
-           "    nop                                 \n"
+           "    setb _P3_7                          \n" // [2,2]
+           "    rlc a                               \n" // [1,1]
+           "    nop                                 \n" // [1,1] //make it even
+           "    jnc bit7skipHighNop$                \n" // [2,2/4|5]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
            "bit7skipHighNop$:                       \n"
-           "    anl ar2,#7                          \n"
-
-           "    djnz r2,loopbit$                    \n"
-           "    djnz r3,startNewByte$               \n"
-           "    nop                                 \n"
-           "    clr _P3_7                          \n"
+           "    clr _P3_7                           \n" // [2,2]
+           "    jc bit7skipLowNop$                  \n" // [2,2/4|5]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "    nop                                 \n" // [1,1]
+           "bit7skipLowNop$:                        \n"
+           "    djnz r2,loopbit$                    \n" // [2,2/4|5|6]
+           "    djnz r3,startNewByte$               \n" // [2,2/4|5|6]
 
            ";restore EA from R6                     \n"
            "    mov a,r6                            \n"


### PR DESCRIPTION
While playing around with a WS2812 light strip, I noticed that sometimes the incorrect colors are displayed.

I found what appears to be a bug with the assembly code that is responsible for streaming the data to the WS2812s.  The root issue seems to be a corrupt R2 register that is never initialized.  This PR fixes that issue.

I also removed the final NOP and the final CLR _PX_X, which aren't really needed since the pin has already been cleared previously by the bit loop.

After making these changes, my WS2812 light strip seems to be behaving properly now.