### PR TITLE
Allow inclusion of Hardware Serial by menu item

### DIFF
--- a/ch55xduino/ch55x/boards.txt
+++ b/ch55xduino/ch55x/boards.txt
@@ -3,6 +3,7 @@
 menu.usb_settings=USB Settings
 menu.upload_method=Upload method
 menu.clock=Clock Source
+menu.uart=Hardware Serial
 ##############################################################
 
 ch552.name=CH552 Board
@@ -33,6 +34,15 @@ ch552.build.mcu=CH552
 
 ch552.upload.use_1200bps_touch=true
 ch552.upload.wait_for_upload_port=false
+
+## Hardware UART Settings
+ch552.menu.uart.nouart=No UART
+ch552.menu.uart.uart0=UART0
+ch552.menu.uart.uart0.build.uart_flags=-DUART0
+ch552.menu.uart.uart1=UART1
+ch552.menu.uart.uart1.build.uart_flags=-DUART1
+ch552.menu.uart.uart0_uart1=UART0 & UART1
+ch552.menu.uart.uart0_uart1.build.uart_flags=-DUART0 -DUART1
 
 ## USB Memory Settings
 ## ----------------------------------------------
@@ -98,6 +108,11 @@ ch551.build.mcu=CH551
 ch551.upload.use_1200bps_touch=true
 ch551.upload.wait_for_upload_port=false
 
+## Hardware UART Settings
+ch551.menu.uart.nouart=No UART
+ch551.menu.uart.uart0=UART0
+ch551.menu.uart.uart0.build.uart_flags=-DUART0
+
 ## USB Memory Settings
 ## ----------------------------------------------
 ch551.menu.usb_settings.usbcdc=Default CDC
@@ -153,6 +168,15 @@ ch559.build.mcu=CH559
 ch559.upload.use_1200bps_touch=true
 ch559.upload.wait_for_upload_port=false
 
+## Hardware UART Settings
+ch559.menu.uart.nouart=No UART
+ch559.menu.uart.uart0=UART0
+ch559.menu.uart.uart0.build.uart_flags=-DUART0
+ch559.menu.uart.uart1=UART1
+ch559.menu.uart.uart1.build.uart_flags=-DUART1
+ch559.menu.uart.uart0_uart1=UART0 & UART1
+ch559.menu.uart.uart0_uart1.build.uart_flags=-DUART0 -DUART1
+
 ## USB Memory Settings
 ## ----------------------------------------------
 ch559.menu.usb_settings.usbcdc=Default CDC
@@ -199,6 +223,15 @@ ch549.build.mcu=CH549
 
 ch549.upload.use_1200bps_touch=true
 ch549.upload.wait_for_upload_port=false
+
+## Hardware UART Settings
+ch549.menu.uart.nouart=No UART
+ch549.menu.uart.uart0=UART0
+ch549.menu.uart.uart0.build.uart_flags=-DUART0
+ch549.menu.uart.uart1=UART1
+ch549.menu.uart.uart1.build.uart_flags=-DUART1
+ch549.menu.uart.uart0_uart1=UART0 & UART1
+ch549.menu.uart.uart0_uart1.build.uart_flags=-DUART0 -DUART1
 
 ## USB Memory Settings
 ## ----------------------------------------------

--- a/ch55xduino/ch55x/boards.txt
+++ b/ch55xduino/ch55x/boards.txt
@@ -36,13 +36,13 @@ ch552.upload.use_1200bps_touch=true
 ch552.upload.wait_for_upload_port=false
 
 ## Hardware UART Settings
-ch552.menu.uart.uart0=UART0
-ch552.menu.uart.uart0.build.uart_flags=-DUART0
-ch552.menu.uart.uart1=UART1
-ch552.menu.uart.uart1.build.uart_flags=-DUART1
 ch552.menu.uart.uart0_uart1=UART0 & UART1
-ch552.menu.uart.uart0_uart1.build.uart_flags=-DUART0 -DUART1
+ch552.menu.uart.uart0=UART0
+ch552.menu.uart.uart0.build.uart_flags=-DNO_UART1
+ch552.menu.uart.uart1=UART1
+ch552.menu.uart.uart1.build.uart_flags=-DNO_UART0
 ch552.menu.uart.nouart=No UART
+ch552.menu.uart.nouart.build.uart_flags=-DNO_UART0 -DNO_UART1
 
 ## USB Memory Settings
 ## ----------------------------------------------
@@ -110,8 +110,9 @@ ch551.upload.wait_for_upload_port=false
 
 ## Hardware UART Settings
 ch551.menu.uart.uart0=UART0
-ch551.menu.uart.uart0.build.uart_flags=-DUART0
+ch551.menu.uart.uart0.build.uart_flags=-DNO_UART1
 ch551.menu.uart.nouart=No UART
+ch551.menu.uart.nouart.build.uart_flags=-DNO_UART0 -DNO_UART1
 
 ## USB Memory Settings
 ## ----------------------------------------------
@@ -169,13 +170,13 @@ ch559.upload.use_1200bps_touch=true
 ch559.upload.wait_for_upload_port=false
 
 ## Hardware UART Settings
-ch559.menu.uart.uart0=UART0
-ch559.menu.uart.uart0.build.uart_flags=-DUART0
-ch559.menu.uart.uart1=UART1
-ch559.menu.uart.uart1.build.uart_flags=-DUART1
 ch559.menu.uart.uart0_uart1=UART0 & UART1
-ch559.menu.uart.uart0_uart1.build.uart_flags=-DUART0 -DUART1
+ch559.menu.uart.uart0=UART0
+ch559.menu.uart.uart0.build.uart_flags=-DNO_UART1
+ch559.menu.uart.uart1=UART1
+ch559.menu.uart.uart1.build.uart_flags=-DNO_UART0
 ch559.menu.uart.nouart=No UART
+ch559.menu.uart.nouart.build.uart_flags=-DNO_UART0 -DNO_UART1
 
 ## USB Memory Settings
 ## ----------------------------------------------
@@ -225,13 +226,13 @@ ch549.upload.use_1200bps_touch=true
 ch549.upload.wait_for_upload_port=false
 
 ## Hardware UART Settings
-ch549.menu.uart.uart0=UART0
-ch549.menu.uart.uart0.build.uart_flags=-DUART0
-ch549.menu.uart.uart1=UART1
-ch549.menu.uart.uart1.build.uart_flags=-DUART1
 ch549.menu.uart.uart0_uart1=UART0 & UART1
-ch549.menu.uart.uart0_uart1.build.uart_flags=-DUART0 -DUART1
+ch549.menu.uart.uart0=UART0
+ch549.menu.uart.uart0.build.uart_flags=-DNO_UART1
+ch549.menu.uart.uart1=UART1
+ch549.menu.uart.uart1.build.uart_flags=-DNO_UART0
 ch549.menu.uart.nouart=No UART
+ch549.menu.uart.nouart.build.uart_flags=-DNO_UART0 -DNO_UART1
 
 ## USB Memory Settings
 ## ----------------------------------------------

--- a/ch55xduino/ch55x/boards.txt
+++ b/ch55xduino/ch55x/boards.txt
@@ -36,13 +36,13 @@ ch552.upload.use_1200bps_touch=true
 ch552.upload.wait_for_upload_port=false
 
 ## Hardware UART Settings
-ch552.menu.uart.nouart=No UART
 ch552.menu.uart.uart0=UART0
 ch552.menu.uart.uart0.build.uart_flags=-DUART0
 ch552.menu.uart.uart1=UART1
 ch552.menu.uart.uart1.build.uart_flags=-DUART1
 ch552.menu.uart.uart0_uart1=UART0 & UART1
 ch552.menu.uart.uart0_uart1.build.uart_flags=-DUART0 -DUART1
+ch552.menu.uart.nouart=No UART
 
 ## USB Memory Settings
 ## ----------------------------------------------
@@ -109,9 +109,9 @@ ch551.upload.use_1200bps_touch=true
 ch551.upload.wait_for_upload_port=false
 
 ## Hardware UART Settings
-ch551.menu.uart.nouart=No UART
 ch551.menu.uart.uart0=UART0
 ch551.menu.uart.uart0.build.uart_flags=-DUART0
+ch551.menu.uart.nouart=No UART
 
 ## USB Memory Settings
 ## ----------------------------------------------
@@ -169,13 +169,13 @@ ch559.upload.use_1200bps_touch=true
 ch559.upload.wait_for_upload_port=false
 
 ## Hardware UART Settings
-ch559.menu.uart.nouart=No UART
 ch559.menu.uart.uart0=UART0
 ch559.menu.uart.uart0.build.uart_flags=-DUART0
 ch559.menu.uart.uart1=UART1
 ch559.menu.uart.uart1.build.uart_flags=-DUART1
 ch559.menu.uart.uart0_uart1=UART0 & UART1
 ch559.menu.uart.uart0_uart1.build.uart_flags=-DUART0 -DUART1
+ch559.menu.uart.nouart=No UART
 
 ## USB Memory Settings
 ## ----------------------------------------------
@@ -225,13 +225,13 @@ ch549.upload.use_1200bps_touch=true
 ch549.upload.wait_for_upload_port=false
 
 ## Hardware UART Settings
-ch549.menu.uart.nouart=No UART
 ch549.menu.uart.uart0=UART0
 ch549.menu.uart.uart0.build.uart_flags=-DUART0
 ch549.menu.uart.uart1=UART1
 ch549.menu.uart.uart1.build.uart_flags=-DUART1
 ch549.menu.uart.uart0_uart1=UART0 & UART1
 ch549.menu.uart.uart0_uart1.build.uart_flags=-DUART0 -DUART1
+ch549.menu.uart.nouart=No UART
 
 ## USB Memory Settings
 ## ----------------------------------------------

--- a/ch55xduino/ch55x/cores/ch55xduino/Arduino.h
+++ b/ch55xduino/ch55x/cores/ch55xduino/Arduino.h
@@ -284,7 +284,7 @@ char USBSerial_read();
 #define USBSerial_println_fd(P,Q) ( Print_print_fd(USBSerial_write,(P),(Q) ) + Print_println(USBSerial_write) )
 #define USBSerial_println_c(P) ( (USBSerial_write(P)) + Print_println(USBSerial_write) )
 
-
+#if defined(UART0)
 #define Serial0_print_s(P) ( Print_print_s(Serial0_write,(P)) )
 #define Serial0_print_sn(P,Q) ( Print_print_sn(Serial0_write,(P),(Q)) )
 #define Serial0_print_i(P) ( Print_print_i(Serial0_write,(P)) )
@@ -305,8 +305,9 @@ char USBSerial_read();
 #define Serial0_println_f(P) ( Print_print_f(Serial0_write,(P)) + Print_println(Serial0_write) )
 #define Serial0_println_fd(P,Q) ( Print_print_fd(Serial0_write,(P),(Q) ) + Print_println(Serial0_write) )
 #define Serial0_println_c(P) ( (Serial0_write(P)) + Print_println(Serial0_write) )
+#endif
 
-
+#if defined(UART1)
 #define Serial1_print_s(P) ( Print_print_s(Serial1_write,(P)) )
 #define Serial1_print_sn(P,Q) ( Print_print_sn(Serial1_write,(P),(Q)) )
 #define Serial1_print_i(P) ( Print_print_i(Serial1_write,(P)) )
@@ -327,6 +328,7 @@ char USBSerial_read();
 #define Serial1_println_f(P) ( Print_print_f(Serial1_write,(P)) + Print_println(Serial1_write) )
 #define Serial1_println_fd(P,Q) ( Print_print_fd(Serial1_write,(P),(Q) ) + Print_println(Serial1_write) )
 #define Serial1_println_c(P) ( (Serial1_write(P)) + Print_println(Serial1_write) )
+#endif
 
 //10K lifecycle DataFlash access on CH551/CH552.
 #define eeprom_write_byte(ADDR,VAL) { DPL=(VAL);DPH=(ADDR);eeprom_write_byte_2_params_DPTR(); }

--- a/ch55xduino/ch55x/cores/ch55xduino/Arduino.h
+++ b/ch55xduino/ch55x/cores/ch55xduino/Arduino.h
@@ -284,7 +284,7 @@ char USBSerial_read();
 #define USBSerial_println_fd(P,Q) ( Print_print_fd(USBSerial_write,(P),(Q) ) + Print_println(USBSerial_write) )
 #define USBSerial_println_c(P) ( (USBSerial_write(P)) + Print_println(USBSerial_write) )
 
-#if defined(UART0)
+#if !defined(NO_UART0)
 #define Serial0_print_s(P) ( Print_print_s(Serial0_write,(P)) )
 #define Serial0_print_sn(P,Q) ( Print_print_sn(Serial0_write,(P),(Q)) )
 #define Serial0_print_i(P) ( Print_print_i(Serial0_write,(P)) )
@@ -307,7 +307,7 @@ char USBSerial_read();
 #define Serial0_println_c(P) ( (Serial0_write(P)) + Print_println(Serial0_write) )
 #endif
 
-#if defined(UART1)
+#if !defined(NO_UART1)
 #define Serial1_print_s(P) ( Print_print_s(Serial1_write,(P)) )
 #define Serial1_print_sn(P,Q) ( Print_print_sn(Serial1_write,(P),(Q)) )
 #define Serial1_print_i(P) ( Print_print_i(Serial1_write,(P)) )

--- a/ch55xduino/ch55x/cores/ch55xduino/HardwareSerial.h
+++ b/ch55xduino/ch55x/cores/ch55xduino/HardwareSerial.h
@@ -5,10 +5,9 @@
 #include <stdio.h>
 #include "include/ch5xx.h"
 
+#if defined(UART0)
 #define SERIAL0_TX_BUFFER_SIZE 16
 #define SERIAL0_RX_BUFFER_SIZE 16
-#define SERIAL1_TX_BUFFER_SIZE 16
-#define SERIAL1_RX_BUFFER_SIZE 16
 
 #define UART0_FLG_SENDING     (1<<0)
 
@@ -24,7 +23,11 @@ void Serial0_end(void);
 
 void uart0IntRxHandler();
 void uart0IntTxHandler();
+#endif
 
+#if defined(UART1)
+#define SERIAL1_TX_BUFFER_SIZE 16
+#define SERIAL1_RX_BUFFER_SIZE 16
 
 uint8_t Serial1(void);
 void Serial1_begin(unsigned long baud);
@@ -38,5 +41,6 @@ void Serial1_end(void);
 
 void uart1IntRxHandler();
 void uart1IntTxHandler();
+#endif
 
 #endif

--- a/ch55xduino/ch55x/cores/ch55xduino/HardwareSerial.h
+++ b/ch55xduino/ch55x/cores/ch55xduino/HardwareSerial.h
@@ -5,7 +5,7 @@
 #include <stdio.h>
 #include "include/ch5xx.h"
 
-#if defined(UART0)
+#if !defined(NO_UART0)
 #define SERIAL0_TX_BUFFER_SIZE 16
 #define SERIAL0_RX_BUFFER_SIZE 16
 
@@ -25,7 +25,7 @@ void uart0IntRxHandler();
 void uart0IntTxHandler();
 #endif
 
-#if defined(UART1)
+#if !defined(NO_UART1)
 #define SERIAL1_TX_BUFFER_SIZE 16
 #define SERIAL1_RX_BUFFER_SIZE 16
 

--- a/ch55xduino/ch55x/cores/ch55xduino/HardwareSerial0.c
+++ b/ch55xduino/ch55x/cores/ch55xduino/HardwareSerial0.c
@@ -1,7 +1,7 @@
 /*
  created by Deqing Sun for use with CH55xduino
  */
-#if defined(UART0)
+#if !defined(NO_UART0)
 #include "HardwareSerial.h"
 
 __xdata unsigned char serial0Initialized;

--- a/ch55xduino/ch55x/cores/ch55xduino/HardwareSerial0ISR.c
+++ b/ch55xduino/ch55x/cores/ch55xduino/HardwareSerial0ISR.c
@@ -1,7 +1,7 @@
 /*
  created by Deqing Sun for use with CH55xduino
  */
-#if defined(UART0)
+#if !defined(NO_UART0)
 #include "HardwareSerial.h"
 
 __xdata uint8_t Receive_Uart0_Buf[SERIAL0_RX_BUFFER_SIZE];   //arduino style serial buffer

--- a/ch55xduino/ch55x/cores/ch55xduino/HardwareSerial0ISR.c
+++ b/ch55xduino/ch55x/cores/ch55xduino/HardwareSerial0ISR.c
@@ -1,7 +1,7 @@
 /*
  created by Deqing Sun for use with CH55xduino
  */
-
+#if defined(UART0)
 #include "HardwareSerial.h"
 
 __xdata uint8_t Receive_Uart0_Buf[SERIAL0_RX_BUFFER_SIZE];   //arduino style serial buffer
@@ -14,7 +14,7 @@ volatile __bit uart0_flag_sending=0;
 
 void uart0IntRxHandler(){
     uint8_t nextHead = (uart0_rx_buffer_head + 1) % SERIAL0_RX_BUFFER_SIZE;
-    
+
     if (nextHead != uart0_rx_buffer_tail) {
         Receive_Uart0_Buf[uart0_rx_buffer_head] = SBUF;
         uart0_rx_buffer_head = nextHead;
@@ -32,5 +32,4 @@ void uart0IntTxHandler(){
         }
     }
 }
-
-
+#endif

--- a/ch55xduino/ch55x/cores/ch55xduino/HardwareSerial1.c
+++ b/ch55xduino/ch55x/cores/ch55xduino/HardwareSerial1.c
@@ -1,4 +1,4 @@
-#if defined(UART1)
+#if !defined(NO_UART1)
 #include "HardwareSerial.h"
 
 __xdata unsigned char serial1Initialized;

--- a/ch55xduino/ch55x/cores/ch55xduino/HardwareSerial1.c
+++ b/ch55xduino/ch55x/cores/ch55xduino/HardwareSerial1.c
@@ -1,3 +1,4 @@
+#if defined(UART1)
 #include "HardwareSerial.h"
 
 __xdata unsigned char serial1Initialized;
@@ -18,7 +19,7 @@ uint8_t Serial1(void){
 }
 
 void Serial1_begin(unsigned long baud){
-    
+
 #if defined(CH551) || defined(CH552)
     U1SM0 = 0;
     U1SMOD = 1;                                                                  //use mode 1 for serial 1
@@ -60,7 +61,7 @@ uint8_t Serial1_write(uint8_t SendDat)
 {
     uint8_t interruptOn = EA;
     EA = 0;
-    
+
     if ( (uart1_tx_buffer_head == uart1_tx_buffer_tail) && (uart1_flag_sending==0) ){    //start to send
         uart1_flag_sending = 1;
 #if defined(CH551) || defined(CH552)
@@ -86,7 +87,7 @@ uint8_t Serial1_write(uint8_t SendDat)
     Transmit_Uart1_Buf[uart1_tx_buffer_head]=SendDat;
 
     uart1_tx_buffer_head = nextHeadPos;
-    
+
     if (interruptOn) EA = 1;
 
     return 1;
@@ -110,3 +111,4 @@ uint8_t Serial1_read(void){
     }
     return 0;
 }
+#endif

--- a/ch55xduino/ch55x/cores/ch55xduino/HardwareSerial1ISR.c
+++ b/ch55xduino/ch55x/cores/ch55xduino/HardwareSerial1ISR.c
@@ -1,4 +1,4 @@
-#if defined(UART1)
+#if !defined(NO_UART1)
 #include "HardwareSerial.h"
 
 __xdata uint8_t Receive_Uart1_Buf[SERIAL1_RX_BUFFER_SIZE];   //arduino style serial buffer

--- a/ch55xduino/ch55x/cores/ch55xduino/HardwareSerial1ISR.c
+++ b/ch55xduino/ch55x/cores/ch55xduino/HardwareSerial1ISR.c
@@ -1,3 +1,4 @@
+#if defined(UART1)
 #include "HardwareSerial.h"
 
 __xdata uint8_t Receive_Uart1_Buf[SERIAL1_RX_BUFFER_SIZE];   //arduino style serial buffer
@@ -40,5 +41,4 @@ void uart1IntTxHandler(){
         }
     }
 }
-
-
+#endif

--- a/ch55xduino/ch55x/cores/ch55xduino/genericPrintSelection.h
+++ b/ch55xduino/ch55x/cores/ch55xduino/genericPrintSelection.h
@@ -13,7 +13,7 @@ void USBSerial_print_sn_func(char * s, __xdata uint8_t size);
 void USBSerial_print_f_func(float f);
 void USBSerial_print_fd_func(float f, __xdata uint8_t digits);
 
-#if defined(UART0)
+#if !defined(NO_UART0)
 void Serial0_print_i_func(long i);
 void Serial0_print_ib_func(long i, __xdata uint8_t base);
 void Serial0_print_u_func(unsigned long u);
@@ -24,7 +24,7 @@ void Serial0_print_f_func(float f);
 void Serial0_print_fd_func(float f, __xdata uint8_t digits);
 #endif
 
-#if defined(UART1)
+#if !defined(NO_UART1)
 void Serial1_print_i_func(long i);
 void Serial1_print_ib_func(long i, __xdata uint8_t base);
 void Serial1_print_u_func(unsigned long u);
@@ -71,7 +71,7 @@ void printNothing();
 )
 #define USBSerial_println(...) {USBSerial_print(__VA_ARGS__);Print_println(USBSerial_write);}
 
-#if defined(UART0)
+#if !defined(NO_UART0)
 #define Serial0_print(...) SERIAL0_SELECT(__VA_ARGS__)(__VA_ARGS__)
 #define SERIAL0_SELECT(...) CONCAT(SERIAL0_SELECT_, NARG(__VA_ARGS__))(__VA_ARGS__)
 #define SERIAL0_SELECT_0() printNothing
@@ -106,7 +106,7 @@ void printNothing();
 #define Serial0_println(...) {Serial0_print(__VA_ARGS__);Print_println(Serial0_write);}
 #endif
 
-#if defined(UART1)
+#if !defined(NO_UART1)
 #define Serial1_print(...) SERIAL1_SELECT(__VA_ARGS__)(__VA_ARGS__)
 #define SERIAL1_SELECT(...) CONCAT(SERIAL1_SELECT_, NARG(__VA_ARGS__))(__VA_ARGS__)
 #define SERIAL1_SELECT_0() printNothing

--- a/ch55xduino/ch55x/cores/ch55xduino/genericPrintSelection.h
+++ b/ch55xduino/ch55x/cores/ch55xduino/genericPrintSelection.h
@@ -13,6 +13,7 @@ void USBSerial_print_sn_func(char * s, __xdata uint8_t size);
 void USBSerial_print_f_func(float f);
 void USBSerial_print_fd_func(float f, __xdata uint8_t digits);
 
+#if defined(UART0)
 void Serial0_print_i_func(long i);
 void Serial0_print_ib_func(long i, __xdata uint8_t base);
 void Serial0_print_u_func(unsigned long u);
@@ -21,7 +22,9 @@ void Serial0_print_s_func(char * s);
 void Serial0_print_sn_func(char * s, __xdata uint8_t size);
 void Serial0_print_f_func(float f);
 void Serial0_print_fd_func(float f, __xdata uint8_t digits);
+#endif
 
+#if defined(UART1)
 void Serial1_print_i_func(long i);
 void Serial1_print_ib_func(long i, __xdata uint8_t base);
 void Serial1_print_u_func(unsigned long u);
@@ -30,6 +33,7 @@ void Serial1_print_s_func(char * s);
 void Serial1_print_sn_func(char * s, __xdata uint8_t size);
 void Serial1_print_f_func(float f);
 void Serial1_print_fd_func(float f, __xdata uint8_t digits);
+#endif
 
 void printNothing();
 
@@ -67,6 +71,7 @@ void printNothing();
 )
 #define USBSerial_println(...) {USBSerial_print(__VA_ARGS__);Print_println(USBSerial_write);}
 
+#if defined(UART0)
 #define Serial0_print(...) SERIAL0_SELECT(__VA_ARGS__)(__VA_ARGS__)
 #define SERIAL0_SELECT(...) CONCAT(SERIAL0_SELECT_, NARG(__VA_ARGS__))(__VA_ARGS__)
 #define SERIAL0_SELECT_0() printNothing
@@ -99,7 +104,9 @@ void printNothing();
                                     unsigned long: _Generic((_2), default: Serial0_print_ub_func) \
 )
 #define Serial0_println(...) {Serial0_print(__VA_ARGS__);Print_println(Serial0_write);}
+#endif
 
+#if defined(UART1)
 #define Serial1_print(...) SERIAL1_SELECT(__VA_ARGS__)(__VA_ARGS__)
 #define SERIAL1_SELECT(...) CONCAT(SERIAL1_SELECT_, NARG(__VA_ARGS__))(__VA_ARGS__)
 #define SERIAL1_SELECT_0() printNothing
@@ -132,6 +139,7 @@ void printNothing();
                                     unsigned long: _Generic((_2), default: Serial1_print_ub_func) \
 )
 #define Serial1_println(...) {Serial1_print(__VA_ARGS__);Print_println(Serial1_write);}
+#endif
 
 
 #define CONCAT(X, Y) CONCAT_(X, Y)

--- a/ch55xduino/ch55x/cores/ch55xduino/genericPrintSerial0.c
+++ b/ch55xduino/ch55x/cores/ch55xduino/genericPrintSerial0.c
@@ -2,7 +2,7 @@
  created by Deqing Sun for use with CH55xduino
  need SDCC 13402 or higher version
  */
-#if defined(UART0)
+#if !defined(NO_UART0)
 #include "Arduino.h"
 
 void Serial0_print_i_func(long i) {

--- a/ch55xduino/ch55x/cores/ch55xduino/genericPrintSerial0.c
+++ b/ch55xduino/ch55x/cores/ch55xduino/genericPrintSerial0.c
@@ -2,7 +2,7 @@
  created by Deqing Sun for use with CH55xduino
  need SDCC 13402 or higher version
  */
-
+#if defined(UART0)
 #include "Arduino.h"
 
 void Serial0_print_i_func(long i) {
@@ -23,3 +23,4 @@ void Serial0_print_s_func(char * s) {
 void Serial0_print_sn_func(char * s, __xdata uint8_t size) {
     Print_print_sn(Serial0_write, s, size);
 }
+#endif

--- a/ch55xduino/ch55x/cores/ch55xduino/genericPrintSerial0Float.c
+++ b/ch55xduino/ch55x/cores/ch55xduino/genericPrintSerial0Float.c
@@ -3,7 +3,7 @@
  need SDCC 13402 or higher version
  float has a separate file to avoid unnecessary linking
  */
-
+#if defined(UART0)
 #include "Arduino.h"
 
 void Serial0_print_f_func(float f) {
@@ -13,3 +13,4 @@ void Serial0_print_f_func(float f) {
 void Serial0_print_fd_func(float f, __xdata uint8_t digits) {
     Print_print_fd(Serial0_write, f, digits);
 }
+#endif

--- a/ch55xduino/ch55x/cores/ch55xduino/genericPrintSerial0Float.c
+++ b/ch55xduino/ch55x/cores/ch55xduino/genericPrintSerial0Float.c
@@ -3,7 +3,7 @@
  need SDCC 13402 or higher version
  float has a separate file to avoid unnecessary linking
  */
-#if defined(UART0)
+#if !defined(NO_UART0)
 #include "Arduino.h"
 
 void Serial0_print_f_func(float f) {

--- a/ch55xduino/ch55x/cores/ch55xduino/genericPrintSerial1.c
+++ b/ch55xduino/ch55x/cores/ch55xduino/genericPrintSerial1.c
@@ -2,7 +2,7 @@
  created by Deqing Sun for use with CH55xduino
  need SDCC 13402 or higher version
  */
-
+#if defined(UART1)
 #include "Arduino.h"
 
 void Serial1_print_i_func(long i) {
@@ -23,3 +23,4 @@ void Serial1_print_s_func(char * s) {
 void Serial1_print_sn_func(char * s, __xdata uint8_t size) {
     Print_print_sn(Serial1_write, s, size);
 }
+#endif

--- a/ch55xduino/ch55x/cores/ch55xduino/genericPrintSerial1.c
+++ b/ch55xduino/ch55x/cores/ch55xduino/genericPrintSerial1.c
@@ -2,7 +2,7 @@
  created by Deqing Sun for use with CH55xduino
  need SDCC 13402 or higher version
  */
-#if defined(UART1)
+#if !defined(NO_UART1)
 #include "Arduino.h"
 
 void Serial1_print_i_func(long i) {

--- a/ch55xduino/ch55x/cores/ch55xduino/genericPrintSerial1Float.c
+++ b/ch55xduino/ch55x/cores/ch55xduino/genericPrintSerial1Float.c
@@ -3,7 +3,7 @@
  need SDCC 13402 or higher version
  float has a separate file to avoid unnecessary linking
  */
-#if defined(UART1)
+#if !defined(NO_UART1)
 #include "Arduino.h"
 
 void Serial1_print_f_func(float f) {

--- a/ch55xduino/ch55x/cores/ch55xduino/genericPrintSerial1Float.c
+++ b/ch55xduino/ch55x/cores/ch55xduino/genericPrintSerial1Float.c
@@ -3,7 +3,7 @@
  need SDCC 13402 or higher version
  float has a separate file to avoid unnecessary linking
  */
-
+#if defined(UART1)
 #include "Arduino.h"
 
 void Serial1_print_f_func(float f) {
@@ -13,3 +13,4 @@ void Serial1_print_f_func(float f) {
 void Serial1_print_fd_func(float f, __xdata uint8_t digits) {
     Print_print_fd(Serial1_write, f, digits);
 }
+#endif

--- a/ch55xduino/ch55x/cores/ch55xduino/main.c
+++ b/ch55xduino/ch55x/cores/ch55xduino/main.c
@@ -37,7 +37,7 @@ __idata __at (0x0C) volatile uint8_t timer0_overflow_count_5th_byte = 0;
 
 void Timer0Interrupt(void) __interrupt (INT_NO_TMR0) __using(1); //located in wiring.c, using register bank 1
 
-#if defined(UART0)
+#if !defined(NO_UART0)
 void Uart0_ISR(void) __interrupt (INT_NO_UART0)
 {
     if (RI){
@@ -51,7 +51,7 @@ void Uart0_ISR(void) __interrupt (INT_NO_UART0)
 }
 #endif
 
-#if defined(UART1)
+#if !defined(NO_UART1)
 void Uart1_ISR(void) __interrupt (INT_NO_UART1)
 {
 #if defined(CH551) || defined(CH552)

--- a/ch55xduino/ch55x/cores/ch55xduino/main.c
+++ b/ch55xduino/ch55x/cores/ch55xduino/main.c
@@ -37,10 +37,11 @@ __idata __at (0x0C) volatile uint8_t timer0_overflow_count_5th_byte = 0;
 
 void Timer0Interrupt(void) __interrupt (INT_NO_TMR0) __using(1); //located in wiring.c, using register bank 1
 
+#if defined(UART0)
 void Uart0_ISR(void) __interrupt (INT_NO_UART0)
 {
     if (RI){
-        uart0IntRxHandler();        
+        uart0IntRxHandler();
         RI =0;
     }
     if (TI){
@@ -48,7 +49,9 @@ void Uart0_ISR(void) __interrupt (INT_NO_UART0)
         TI =0;
     }
 }
+#endif
 
+#if defined(UART1)
 void Uart1_ISR(void) __interrupt (INT_NO_UART1)
 {
 #if defined(CH551) || defined(CH552)
@@ -82,6 +85,7 @@ void Uart1_ISR(void) __interrupt (INT_NO_UART1)
     }
 #endif
 }
+#endif
 
 typedef void (*voidFuncPtr)(void);
 extern __xdata voidFuncPtr intFunc[];
@@ -130,5 +134,3 @@ unsigned char _sdcc_external_startup (void) __nonbanked
 {
     return 0;
 }
-
-

--- a/ch55xduino/ch55x/platform.txt
+++ b/ch55xduino/ch55x/platform.txt
@@ -78,6 +78,7 @@ compiler.systemincludes="-I{compiler.syslibs.stdlib.path}/include"
 
 # This can be overridden in boards.txt
 build.extra_flags=
+build.uart_flags=
 
 # These can be overridden in platform.local.txt
 compiler.c.extra_flags=
@@ -92,13 +93,13 @@ compiler.elf2hex.extra_flags=
 # --------------------
 
 ## Compile c files (re1)
-recipe.c.o.pattern="{compiler.wrapper.path}/{compiler.c.wrapper}" "{compiler.path}/{compiler.c.cmd}" "{source_file}" "{object_file}" re1 {compiler.c.flags} -mmcs51 -D{build.mcu} -DF_CPU={build.f_cpu} -DF_EXT_OSC={build.f_oscillator_external} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.c.extra_flags} {build.extra_flags} {includes} {compiler.systemincludes}
+recipe.c.o.pattern="{compiler.wrapper.path}/{compiler.c.wrapper}" "{compiler.path}/{compiler.c.cmd}" "{source_file}" "{object_file}" re1 {compiler.c.flags} -mmcs51 -D{build.mcu} -DF_CPU={build.f_cpu} -DF_EXT_OSC={build.f_oscillator_external} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.c.extra_flags} {build.extra_flags} {build.uart_flags} {includes} {compiler.systemincludes}
 
 ## Compile c++ files (re2)
-recipe.cpp.o.pattern="{compiler.wrapper.path}/{compiler.cpp.wrapper}" "{compiler.path}/{compiler.cpp.cmd}" "{source_file}" "{object_file}" re2 {compiler.cpp.flags} -mmcs51 -D{build.mcu} -DF_CPU={build.f_cpu} -DF_EXT_OSC={build.f_oscillator_external} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {includes} {compiler.systemincludes}
+recipe.cpp.o.pattern="{compiler.wrapper.path}/{compiler.cpp.wrapper}" "{compiler.path}/{compiler.cpp.cmd}" "{source_file}" "{object_file}" re2 {compiler.cpp.flags} -mmcs51 -D{build.mcu} -DF_CPU={build.f_cpu} -DF_EXT_OSC={build.f_oscillator_external} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {build.uart_flags} {includes} {compiler.systemincludes}
 
 ##FIXME Compile S files (re3)
-recipe.S.o.pattern="{compiler.path}/{compiler.c.cmd}" re3 {compiler.S.flags} -mmcs51 -D{build.mcu} -DF_CPU={build.f_cpu} -DF_EXT_OSC={build.f_oscillator_external} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.S.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{object_file}"
+recipe.S.o.pattern="{compiler.path}/{compiler.c.cmd}" re3 {compiler.S.flags} -mmcs51 -D{build.mcu} -DF_CPU={build.f_cpu} -DF_EXT_OSC={build.f_oscillator_external} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.S.extra_flags} {build.extra_flags} {build.uart_flags} {includes} "{source_file}" -o "{object_file}"
 
 ## Create archives (re4)
 # archive_file_path is needed for backwards compatibility with IDE 1.6.5 or older, IDE 1.6.6 or newer overrides this value
@@ -125,9 +126,9 @@ recipe.size.regex.data=^(?:\s+EXTERNAL RAM)\s+0x[A-Fa-f0-9]+\s+0x[A-Fa-f0-9]+\s+
 
 ## Preprocessor (re11, re12)
 preproc.includes.flags=-M -MG -MP
-recipe.preproc.includes="{compiler.path.wrapper}/{compiler.cpp.wrapper}" "{compiler.path}/{compiler.cpp.cmd}" re11 {compiler.cpp.flags} {preproc.includes.flags} -mmcs51 -D{build.mcu} -DF_CPU={build.f_cpu} -DF_EXT_OSC={build.f_oscillator_external} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {includes} "{source_file}"
+recipe.preproc.includes="{compiler.path.wrapper}/{compiler.cpp.wrapper}" "{compiler.path}/{compiler.cpp.cmd}" re11 {compiler.cpp.flags} {preproc.includes.flags} -mmcs51 -D{build.mcu} -DF_CPU={build.f_cpu} -DF_EXT_OSC={build.f_oscillator_external} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {build.uart_flags} {includes} "{source_file}"
 preproc.macros.flags=-E -MC
-recipe.preproc.macros="{compiler.wrapper.path}/{compiler.cpp.cmd}.sh" "{compiler.path}/{compiler.cpp.cmd}" "{source_file}" "{preprocessed_file_path}" re12 {compiler.cpp.flags} {preproc.macros.flags} -mmcs51 -D{build.mcu} -DF_CPU={build.f_cpu} -DF_EXT_OSC={build.f_oscillator_external} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {includes} {compiler.systemincludes}
+recipe.preproc.macros="{compiler.wrapper.path}/{compiler.cpp.cmd}.sh" "{compiler.path}/{compiler.cpp.cmd}" "{source_file}" "{preprocessed_file_path}" re12 {compiler.cpp.flags} {preproc.macros.flags} -mmcs51 -D{build.mcu} -DF_CPU={build.f_cpu} -DF_EXT_OSC={build.f_oscillator_external} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {build.uart_flags} {includes} {compiler.systemincludes}
 
 
 # vnproch55x


### PR DESCRIPTION
This PR adds menu items to be able to select which hardware serial items (if any) to be included in the build.
This is a potential solution for issue #113 

Here are the results when compiling an empty sketch with CH552 (Default CDC @ 24 MHz):
No UART: `Sketch uses 3584 (25%) of 14336 bytes.  Global variables use 23 (2%) of 876 bytes.`
UART0:  `Sketch uses 3919 (27%) of 14336 bytes.  Global variables use 59 (6%) of 876 bytes.`
UART1:  `Sketch uses 3919 (27%) of 14336 bytes.  Global variables use 59 (6%) of 876 bytes.`
UART0 & UART1:  `Sketch uses 4123 (28%) of 14336 bytes.  Global variables use 95 (10%) of 876 bytes.`

So, not a dramatic difference, but sometimes every little bit helps (particularly on RAM usage)

Savings for CH551 is a bit more dramatic...
No UART: `Sketch uses 3568 (34%) of 10240 bytes.  Global variables use 23 (6%) of 364 bytes.`
UART0:  `Sketch uses 3903 (38%) of 10240 bytes.  Global variables use 59 (16%) of 364 bytes.`
Original (i.e. UART0 & UART1): `Sketch uses 4107 (40%) of 10240 bytes.  Global variables use 95 (26%) of 364 bytes.`